### PR TITLE
fix: kafka cluster ca cert reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In order to do anything with this external to the cluster, we'll need to get the
 To download, these are commands that should work if you are in the roo of the repo of this Readme:
 
 ```bash
-kubectl get secret tutuser -n mykafka -o json | jq -r '.data."ca.crt"' | base64 -d > kafkaca.crt
+kubectl get secret mykafkacluster-cluster-ca-cert -n mykafka -o json | jq -r '.data."ca.crt"' | base64 -d > kafkaca.crt
 kubectl get secret tutuser -n mykafka -o json | jq -r '.data."user.crt"' | base64 -d > tutuser.crt
 kubectl get secret tutuser -n mykafka -o json | jq -r '.data."user.key"' | base64 -d > tutuser.key
 ```

--- a/dotnet/MyKafka/Consumer.cs
+++ b/dotnet/MyKafka/Consumer.cs
@@ -19,7 +19,7 @@ public class MyKafkaConsumer
             SslCertificateLocation = SslCertificateLocation,
             SslKeyLocation = SslKeyLocation,
             SslCaLocation = SslCaLocation,
-            EnableSslCertificateVerification = false,
+            EnableSslCertificateVerification = true,
             MaxInFlight = 2,
         };
         MessageNum = messageNum;

--- a/dotnet/MyKafka/Producer.cs
+++ b/dotnet/MyKafka/Producer.cs
@@ -18,7 +18,7 @@ public class MyKafkaProducer
             SecurityProtocol = SecurityProtocol.Ssl,
             SslKeyLocation = SslKeyLocation,
             SslCaLocation = SslCaLocation,
-            EnableSslCertificateVerification = false,
+            EnableSslCertificateVerification = true,
             Partitioner = Partitioner.Random,
             MaxInFlight = 1,
         };

--- a/go/main.go
+++ b/go/main.go
@@ -33,7 +33,7 @@ func main() {
 		CaCertPath:               os.Getenv("MYKAFKA_CACRT_PATH"),
 		MessageCount:             env.GetEnvAsIntOrDefault("MYKAFKA_MESSAGE_NUM", "3"),
 		SecurityProtocol:         "SSL",
-		EnableSSLCerterification: false,
+		EnableSSLCerterification: true,
 	}
 
 	// connect as producer


### PR DESCRIPTION
retrieve the cluster ca cert from the `<cluster>-cluster-ca-cert`
secret, instead of using the one from the user secret. re-enable ssl
verification now that it works.