### PR TITLE
fix: add kubectl wait command to the kafka shell script

### DIFF
--- a/start_kafkashell.sh
+++ b/start_kafkashell.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
+# fail script of any command fails
+set -e
+
 STRIMZI_VERSION=${STRIMZI_VERSION:-"0.29.0"}
 KAFKA_VERSION=${KAFKA_VERSION:-"3.2.0"}
 KAFKA_CLUSTER_NAME=${KAFKA_CLUSTER_NAME:-"mykafkacluster"}
 KAFKA_NAMESPACE=${KAFKA_NAMESPACE:-"mykafka"}
-
 
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -48,8 +50,8 @@ spec:
       secretName: ${KAFKA_CLUSTER_NAME}-cluster-ca-cert
 EOF
 
-echo "Giving the pod a moment to create"
-sleep 5
+echo "Waiting for the pod to create"
+kubectl wait --namespace mykafka --for=condition=ready pod --timeout=-1s kafkashell
 kubectl exec --namespace mykafka -it kafkashell -- bash -c "cd /opt/kafka/clustertls; keytool -keystore /tmp/truststore.jks -storepass tutpass -noprompt -alias cluster-ca -import -file ca.crt -storetype PKCS12"
 kubectl exec --namespace mykafka -it kafkashell -- bash -c "cd /opt/kafka/usertls; openssl pkcs12 -export -in user.crt -inkey user.key -name custom-key -password pass:tutpass -out /tmp/sreuser.p12"
 kubectl exec --namespace mykafka -it kafkashell -- bash -c "printf \"security.protocol=SSL\nssl.truststore.location=/tmp/truststore.jks\nssl.truststore.password=tutpass\nssl.keystore.location=/tmp/sreuser.p12\nssl.keystore.password=tutpass\n\" > /tmp/client.properties"

--- a/start_kafkashell.sh
+++ b/start_kafkashell.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# fail script of any command fails
+# fail script if any command fails
 set -e
 
 STRIMZI_VERSION=${STRIMZI_VERSION:-"0.29.0"}


### PR DESCRIPTION
super minor change.  my pod was taking longer than 5 seconds to create,
so the script would throw a bunch of errors for me. adding the wait
command would ensure that the pod is up before proceeding regardless of
the time that it takes.